### PR TITLE
Fix compilation errors on Linux

### DIFF
--- a/snakes-ladders/Dice.h
+++ b/snakes-ladders/Dice.h
@@ -29,7 +29,7 @@ private:
     int spriteNum;
 
 signals:
-    diceClicked();
+    void diceClicked();
 };
 
 #endif // DICE_H

--- a/snakes-ladders/TextBox.h
+++ b/snakes-ladders/TextBox.h
@@ -6,7 +6,7 @@
 #include <QTextCursor>
 #include <QObject>
 
-#include <qDebug>
+#include <QDebug>
 class TextBox: public QObject, public QGraphicsRectItem {
     Q_OBJECT
 public:


### PR DESCRIPTION
Most filesystems on GNU/Linux are case sensitive, so `#include <qDebug>` didn't work.

Also, g++ compiled about `diceClicked` having no type.
